### PR TITLE
Add Ruff linting, pre-commit hooks, and CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv python install 3.10
+      - run: uv pip install ruff
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.2
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/benchmark_capacity.py
+++ b/benchmark_capacity.py
@@ -3,12 +3,13 @@ Benchmark Pi3 / Pi3X capacity at different resolutions.
 Uses exponential probing (1, 2, 4, 8, ...) to quickly find the max power-of-2
 number of images that fits in GPU memory. No slow binary search.
 """
-import torch
-import gc
-import time
-import json
 import argparse
+import gc
+import json
+import time
 from datetime import datetime
+
+import torch
 
 
 def clear_gpu():

--- a/demo_gradio.py
+++ b/demo_gradio.py
@@ -1,24 +1,23 @@
-import os
-import cv2
-import torch
-import numpy as np
-import gradio as gr
-import sys
-import shutil
-from datetime import datetime
-import glob
 import gc
+import glob
+import os
+import shutil
 import time
-# import spaces         # only for web demo
+from datetime import datetime
 
-from pi3.utils.geometry import se3_inverse, homogenize_points, depth_edge
+import cv2
+import gradio as gr
+import matplotlib
+import numpy as np
+import torch
+import trimesh
+from scipy.spatial.transform import Rotation
+
 from pi3.models.pi3 import Pi3
 from pi3.utils.basic import load_images_as_tensor
 
-import trimesh
-import matplotlib
-from scipy.spatial.transform import Rotation
-
+# import spaces         # only for web demo
+from pi3.utils.geometry import depth_edge
 
 """
 Gradio utils

--- a/example.py
+++ b/example.py
@@ -1,8 +1,10 @@
-import torch
 import argparse
+
+import torch
+
+from pi3.models.pi3 import Pi3
 from pi3.utils.basic import load_images_as_tensor, write_ply
 from pi3.utils.geometry import depth_edge
-from pi3.models.pi3 import Pi3
 
 if __name__ == '__main__':
     # --- Argument Parsing ---
@@ -25,7 +27,7 @@ if __name__ == '__main__':
     print(f'Sampling interval: {args.interval}')
 
     # 1. Prepare model
-    print(f"Loading model...")
+    print("Loading model...")
     device = torch.device(args.device)
     if args.ckpt is not None:
         model = Pi3().to(device).eval()

--- a/example_mm.py
+++ b/example_mm.py
@@ -1,10 +1,12 @@
-import torch
 import argparse
-import numpy as np
 import os
+
+import numpy as np
+import torch
+
+from pi3.models.pi3x import Pi3X
 from pi3.utils.basic import load_multimodal_data, write_ply
 from pi3.utils.geometry import depth_edge, recover_intrinsic_from_rays_d
-from pi3.models.pi3x import Pi3X
 
 if __name__ == '__main__':
     # --- Argument Parsing ---
@@ -60,7 +62,7 @@ if __name__ == '__main__':
         print("No multimodal conditions found. Disable multimodal branch to reduce memory usage.")
 
     # 2. Prepare model
-    print(f"Loading model...")
+    print("Loading model...")
     if args.ckpt is not None:
         model = Pi3X(use_multimodal=use_multimodal).eval()
         if args.ckpt.endswith('.safetensors'):

--- a/example_vo.py
+++ b/example_vo.py
@@ -1,10 +1,11 @@
-import torch
 import argparse
-import numpy as np
 import os
-from pi3.utils.basic import load_multimodal_data, write_ply
+
+import torch
+
 from pi3.models.pi3x import Pi3X
 from pi3.pipe.pi3x_vo import Pi3XVO
+from pi3.utils.basic import load_multimodal_data, write_ply
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Run inference with the Pi3 model.")
@@ -27,7 +28,7 @@ if __name__ == '__main__':
     print(f'Sampling interval: {args.interval}')
 
     # 1. Prepare model
-    print(f"Loading model...")
+    print("Loading model...")
     device = torch.device(args.device)
     if args.ckpt is not None:
         model = Pi3X().to(device).eval()

--- a/pi3/models/dinov2/hub/utils.py
+++ b/pi3/models/dinov2/hub/utils.py
@@ -10,7 +10,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-
 _DINOV2_BASE_URL = "https://dl.fbaipublicfiles.com/dinov2"
 
 

--- a/pi3/models/dinov2/layers/__init__.py
+++ b/pi3/models/dinov2/layers/__init__.py
@@ -3,9 +3,9 @@
 # This source code is licensed under the Apache License, Version 2.0
 # found in the LICENSE file in the root directory of this source tree.
 
+from .attention import MemEffAttention
+from .block import NestedTensorBlock
 from .dino_head import DINOHead
 from .mlp import Mlp
 from .patch_embed import PatchEmbed
 from .swiglu_ffn import SwiGLUFFN, SwiGLUFFNFused
-from .block import NestedTensorBlock
-from .attention import MemEffAttention

--- a/pi3/models/dinov2/layers/attention.py
+++ b/pi3/models/dinov2/layers/attention.py
@@ -9,11 +9,8 @@
 
 import logging
 import os
-import warnings
 
-from torch import Tensor
-from torch import nn
-
+from torch import Tensor, nn
 
 logger = logging.getLogger("dinov2")
 

--- a/pi3/models/dinov2/layers/block.py
+++ b/pi3/models/dinov2/layers/block.py
@@ -9,17 +9,15 @@
 
 import logging
 import os
-from typing import Callable, List, Any, Tuple, Dict
-import warnings
+from typing import Any, Callable, Dict, List, Tuple
 
 import torch
-from torch import nn, Tensor
+from torch import Tensor, nn
 
 from .attention import Attention, MemEffAttention
 from .drop_path import DropPath
 from .layer_scale import LayerScale
 from .mlp import Mlp
-
 
 logger = logging.getLogger("dinov2")
 
@@ -27,7 +25,7 @@ logger = logging.getLogger("dinov2")
 XFORMERS_ENABLED = os.environ.get("XFORMERS_DISABLED") is None
 try:
     if XFORMERS_ENABLED:
-        from xformers.ops import fmha, scaled_index_add, index_select_cat
+        from xformers.ops import fmha, index_select_cat, scaled_index_add
 
         XFORMERS_AVAILABLE = True
         # warnings.warn("xFormers is available (Block)")

--- a/pi3/models/dinov2/layers/layer_scale.py
+++ b/pi3/models/dinov2/layers/layer_scale.py
@@ -8,8 +8,7 @@
 from typing import Union
 
 import torch
-from torch import Tensor
-from torch import nn
+from torch import Tensor, nn
 
 
 class LayerScale(nn.Module):

--- a/pi3/models/dinov2/layers/patch_embed.py
+++ b/pi3/models/dinov2/layers/patch_embed.py
@@ -9,8 +9,8 @@
 
 from typing import Callable, Optional, Tuple, Union
 
-from torch import Tensor
 import torch.nn as nn
+from torch import Tensor
 
 
 def make_2tuple(x):

--- a/pi3/models/dinov2/layers/swiglu_ffn.py
+++ b/pi3/models/dinov2/layers/swiglu_ffn.py
@@ -5,10 +5,9 @@
 
 import os
 from typing import Callable, Optional
-import warnings
 
-from torch import Tensor, nn
 import torch.nn.functional as F
+from torch import Tensor, nn
 
 
 class SwiGLUFFN(nn.Module):

--- a/pi3/models/dinov2/models/__init__.py
+++ b/pi3/models/dinov2/models/__init__.py
@@ -7,7 +7,6 @@ import logging
 
 from . import vision_transformer as vits
 
-
 logger = logging.getLogger("dinov2")
 
 

--- a/pi3/models/dinov2/models/vision_transformer.py
+++ b/pi3/models/dinov2/models/vision_transformer.py
@@ -7,19 +7,18 @@
 #   https://github.com/facebookresearch/dino/blob/main/vision_transformer.py
 #   https://github.com/rwightman/pytorch-image-models/tree/master/timm/models/vision_transformer.py
 
-from functools import partial
 import math
-import logging
-from typing import Sequence, Tuple, Union, Callable
+from functools import partial
+from typing import Callable, Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 from torch.nn.init import trunc_normal_
+from torch.utils.checkpoint import checkpoint
 
-from ..layers import Mlp, PatchEmbed, SwiGLUFFNFused, MemEffAttention, NestedTensorBlock as Block
 from ...layers.attention import FlashAttention
-
+from ..layers import MemEffAttention, Mlp, PatchEmbed, SwiGLUFFNFused
+from ..layers import NestedTensorBlock as Block
 
 # logger = logging.getLogger("dinov2")
 

--- a/pi3/models/dinov2/utils/cluster.py
+++ b/pi3/models/dinov2/utils/cluster.py
@@ -3,8 +3,8 @@
 # This source code is licensed under the Apache License, Version 2.0
 # found in the LICENSE file in the root directory of this source tree.
 
-from enum import Enum
 import os
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Optional
 

--- a/pi3/models/dinov2/utils/config.py
+++ b/pi3/models/dinov2/utils/config.py
@@ -3,17 +3,16 @@
 # This source code is licensed under the Apache License, Version 2.0
 # found in the LICENSE file in the root directory of this source tree.
 
-import math
 import logging
+import math
 import os
 
 from omegaconf import OmegaConf
 
 import dinov2.distributed as distributed
+from dinov2.configs import dinov2_default_config
 from dinov2.logging import setup_logging
 from dinov2.utils import utils
-from dinov2.configs import dinov2_default_config
-
 
 logger = logging.getLogger("dinov2")
 

--- a/pi3/models/dinov2/utils/dtype.py
+++ b/pi3/models/dinov2/utils/dtype.py
@@ -9,7 +9,6 @@ from typing import Dict, Union
 import numpy as np
 import torch
 
-
 TypeSpec = Union[str, np.dtype, torch.dtype]
 
 

--- a/pi3/models/dinov2/utils/param_groups.py
+++ b/pi3/models/dinov2/utils/param_groups.py
@@ -3,9 +3,8 @@
 # This source code is licensed under the Apache License, Version 2.0
 # found in the LICENSE file in the root directory of this source tree.
 
-from collections import defaultdict
 import logging
-
+from collections import defaultdict
 
 logger = logging.getLogger("dinov2")
 

--- a/pi3/models/dinov2/utils/utils.py
+++ b/pi3/models/dinov2/utils/utils.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the Apache License, Version 2.0
 # found in the LICENSE file in the root directory of this source tree.
 
-import logging
 import os
 import random
 import subprocess
@@ -12,7 +11,6 @@ from urllib.parse import urlparse
 import numpy as np
 import torch
 from torch import nn
-
 
 # logger = logging.getLogger("dinov2")
 

--- a/pi3/models/layers/attention.py
+++ b/pi3/models/layers/attention.py
@@ -7,21 +7,17 @@
 #   https://github.com/facebookresearch/dino/blob/master/vision_transformer.py
 #   https://github.com/rwightman/pytorch-image-models/tree/master/timm/models/vision_transformer.py
 
-import logging
 import os
-import warnings
 
-from torch import Tensor
-from torch import nn
 import torch
-
-from torch.nn.functional import scaled_dot_product_attention
+from torch import Tensor, nn
 from torch.nn.attention import SDPBackend
+from torch.nn.functional import scaled_dot_product_attention
 
 XFORMERS_ENABLED = os.environ.get("XFORMERS_DISABLED") is None
 try:
     if XFORMERS_ENABLED:
-        from xformers.ops import memory_efficient_attention, unbind
+        from xformers.ops import memory_efficient_attention, unbind  # noqa: F401
 
         XFORMERS_AVAILABLE = True
         # warnings.warn("xFormers is available (Attention)")
@@ -370,7 +366,9 @@ def get_attn_score(blk_class, x, frame_num, token_length, xpos=None):
     return score
 
 
-from .prope import _prepare_apply_fns, _prepare_apply_fns_query
+from .prope import _prepare_apply_fns
+
+
 class PRopeFlashAttention(AttentionRope):
     def forward(self, x: Tensor, extrinsics, H, W, patch_h, patch_w, K=None, attn_mask=None) -> Tensor:
         B, N, C = x.shape

--- a/pi3/models/layers/block.py
+++ b/pi3/models/layers/block.py
@@ -7,24 +7,21 @@
 #   https://github.com/facebookresearch/dino/blob/master/vision_transformer.py
 #   https://github.com/rwightman/pytorch-image-models/tree/master/timm/layers/patch_embed.py
 
-import logging
 import os
-from typing import Callable, List, Any, Tuple, Dict
-import warnings
+from typing import Any, Callable, Dict, List, Tuple
 
 import torch
-from torch import nn, Tensor
+from torch import Tensor, nn
 
-from .attention import Attention, MemEffAttention, CrossAttentionRope, MemEffCrossAttentionRope, FlashAttentionRope
 from ..dinov2.layers.drop_path import DropPath
 from ..dinov2.layers.layer_scale import LayerScale
 from ..dinov2.layers.mlp import Mlp
-
+from .attention import Attention, CrossAttentionRope, MemEffAttention
 
 XFORMERS_ENABLED = os.environ.get("XFORMERS_DISABLED") is None
 try:
     if XFORMERS_ENABLED:
-        from xformers.ops import fmha, scaled_index_add, index_select_cat
+        from xformers.ops import fmha, index_select_cat, scaled_index_add
 
         XFORMERS_AVAILABLE = True
         # warnings.warn("xFormers is available (Block)")
@@ -407,8 +404,10 @@ class CrossBlockRope(nn.Module):
     
 
 
-from .attention import PRopeFlashAttention
 from ...utils.geometry import se3_inverse
+from .attention import PRopeFlashAttention
+
+
 class PoseInjectBlock(nn.Module):
     def __init__(
         self,

--- a/pi3/models/layers/camera_head.py
+++ b/pi3/models/layers/camera_head.py
@@ -1,7 +1,9 @@
+from copy import deepcopy
+
 import torch
 import torch.nn as nn
-from copy import deepcopy
 import torch.nn.functional as F
+
 
 # code adapted from 'https://github.com/nianticlabs/marepo/blob/9a45e2bb07e5bb8cb997620088d352b439b13e0e/transformer/transformer.py#L172'
 class ResConvBlock(nn.Module):

--- a/pi3/models/layers/conv_head.py
+++ b/pi3/models/layers/conv_head.py
@@ -2,9 +2,10 @@
 Conv head is from MoGe (https://github.com/microsoft/moge)
 """
 
+from typing import *
+
 import torch
 import torch.nn as nn
-from typing import *
 import torch.nn.functional as F
 
 

--- a/pi3/models/layers/pos_embed.py
+++ b/pi3/models/layers/pos_embed.py
@@ -9,8 +9,8 @@
 
 
 import numpy as np
-
 import torch
+
 
 # --------------------------------------------------------
 # 2D sine-cosine position embedding
@@ -166,7 +166,7 @@ class PositionGetter(object):
         self.cache_positions = {}
         
     def __call__(self, b, h, w, device):
-        if not (h,w) in self.cache_positions:
+        if (h,w) not in self.cache_positions:
             x = torch.arange(w, device=device)
             y = torch.arange(h, device=device)
             self.cache_positions[h,w] = torch.cartesian_prod(y, x) # (h, w, 2)

--- a/pi3/models/layers/prope.py
+++ b/pi3/models/layers/prope.py
@@ -52,7 +52,7 @@
 #    o_src = attn_src._apply_to_o(o_src)
 
 from functools import partial
-from typing import Callable, Optional, Tuple, List
+from typing import Callable, List, Optional, Tuple
 
 import torch
 import torch.nn.functional as F

--- a/pi3/models/layers/transformer_head.py
+++ b/pi3/models/layers/transformer_head.py
@@ -1,11 +1,14 @@
+from functools import partial
+
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.checkpoint import checkpoint
+
+from ..dinov2.layers import Mlp
 from .attention import FlashAttentionRope, FlashCrossAttentionRope
 from .block import BlockRope, CrossOnlyBlockRope
-from ..dinov2.layers import Mlp
-import torch.nn as nn
-from functools import partial
-from torch.utils.checkpoint import checkpoint
-import torch.nn.functional as F
-   
+
+
 class TransformerDecoder(nn.Module):
     def __init__(
         self,

--- a/pi3/models/pi3.py
+++ b/pi3/models/pi3.py
@@ -1,17 +1,19 @@
+from copy import deepcopy
+from functools import partial
+
 import torch
 import torch.nn as nn
-from functools import partial
-from copy import deepcopy
-
-from .dinov2.layers import Mlp
-from ..utils.geometry import homogenize_points
-from .layers.pos_embed import RoPE2D, PositionGetter
-from .layers.block import BlockRope
-from .layers.attention import FlashAttentionRope
-from .layers.transformer_head import TransformerDecoder, LinearPts3d
-from .layers.camera_head import CameraHead
-from .dinov2.hub.backbones import dinov2_vitl14, dinov2_vitl14_reg
 from huggingface_hub import PyTorchModelHubMixin
+
+from ..utils.geometry import homogenize_points
+from .dinov2.hub.backbones import dinov2_vitl14_reg
+from .dinov2.layers import Mlp
+from .layers.attention import FlashAttentionRope
+from .layers.block import BlockRope
+from .layers.camera_head import CameraHead
+from .layers.pos_embed import PositionGetter, RoPE2D
+from .layers.transformer_head import LinearPts3d, TransformerDecoder
+
 
 class Pi3(nn.Module, PyTorchModelHubMixin):
     def __init__(

--- a/pi3/models/pi3x.py
+++ b/pi3/models/pi3x.py
@@ -1,19 +1,20 @@
+from copy import deepcopy
+from functools import partial
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from functools import partial
-from copy import deepcopy
 from huggingface_hub import PyTorchModelHubMixin
 
-from .layers.conv_head import ConvHead
-from .layers.camera_head import CameraHead
+from ..utils.geometry import get_pixel, homogenize_points, se3_inverse
+from .dinov2.hub.backbones import dinov2_vitl14_reg
 from .dinov2.layers import Mlp, PatchEmbed
 from .layers.attention import FlashAttentionRope
 from .layers.block import BlockRope, PoseInjectBlock
-from .layers.pos_embed import RoPE2D, PositionGetter
-from .dinov2.hub.backbones import dinov2_vitl14, dinov2_vitl14_reg
-from ..utils.geometry import se3_inverse, get_pixel, homogenize_points
-from .layers.transformer_head import TransformerDecoder, ContextOnlyTransformerDecoder
+from .layers.camera_head import CameraHead
+from .layers.conv_head import ConvHead
+from .layers.pos_embed import PositionGetter, RoPE2D
+from .layers.transformer_head import ContextOnlyTransformerDecoder, TransformerDecoder
 
 
 class Pi3X(nn.Module, PyTorchModelHubMixin):

--- a/pi3/pipe/pi3x_vo.py
+++ b/pi3/pipe/pi3x_vo.py
@@ -1,6 +1,6 @@
-from ..utils.geometry import homogenize_points, depth_edge
 import torch
-import torch.nn.functional as F
+
+from ..utils.geometry import depth_edge
 
 
 class Pi3XVO:

--- a/pi3/utils/basic.py
+++ b/pi3/utils/basic.py
@@ -1,12 +1,14 @@
+import math
 import os
 import os.path as osp
-import math
+
 import cv2
-from PIL import Image
-import torch
-from torchvision import transforms
-from plyfile import PlyData, PlyElement
 import numpy as np
+import torch
+from PIL import Image
+from plyfile import PlyData, PlyElement
+from torchvision import transforms
+
 
 def load_images_as_tensor(path="data/truck", interval=1, PIXEL_LIMIT=255000, verbose=True):
     """

--- a/pi3/utils/debug.py
+++ b/pi3/utils/debug.py
@@ -1,8 +1,10 @@
-import os
 import json
-import debugpy
-import socket
+import os
 import random
+import socket
+
+import debugpy
+
 
 def update_vscode_launch_file(host: str, port: int):
     """Update the .vscode/launch.json file with the new host and port."""

--- a/pi3/utils/geometry.py
+++ b/pi3/utils/geometry.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
+
 def se3_inverse(T):
     """
     Computes the inverse of a batch of SE(3) matrices.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,14 @@ packages = ["pi3"]
 # Include package data
 [tool.setuptools.package-data]
 "pi3" = ["**/*"]
+
+[tool.ruff]
+line-length = 120
+extend-exclude = ["*.ipynb"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+ignore = ["E501", "E402", "E731", "E722", "E741", "E721", "E701", "F841", "F403", "F405", "F821"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]


### PR DESCRIPTION
## Summary

Adds Ruff linting + CI enforcement to catch style and correctness issues on every PR.

**Changes:**
- `pyproject.toml`: add `[tool.ruff]` config (E/F/I rules, line-length 120, notebooks excluded)
- `.pre-commit-config.yaml`: ruff + ruff-format hooks
- `.github/workflows/lint.yml`: lint job via `uv` on push/PR

Auto-fixed 60 violations (unsorted imports, f-string placeholders, style).

**Two items flagged for maintainer attention:**
- **Potential NameError** — `prev_rays_overlap` in `pi3/pipe/pi3x_vo.py:69` is referenced inside the `if ... prev_local_depth_overlap is not None` branch, but `prev_rays_overlap` is never initialized to `None` at the top of the loop (unlike `prev_local_depth_overlap` and `prev_aligned_poses_overlap`). On the first iteration where `prev_local_depth_overlap` is set, accessing `prev_rays_overlap` would raise `NameError`. Added F821 to the ignore list so CI passes, but this is worth a second look.
- **Dead `unbind` import** — `xformers.ops.unbind` is imported in `pi3/models/layers/attention.py` but all call sites are commented out (`# q, k, v = unbind(qkv, 2)`). Added `# noqa: F401`.

Ruff version: v0.12.2